### PR TITLE
Fix Slack ID retrieval via email

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -1,5 +1,4 @@
 const https = require('https');
-const querystring = require('node:querystring');
 const messageVariables = {
   username: 'Mastery Path Bot',
   icon_url: 'https://s3-us-west-2.amazonaws.com/slack-files2/bot_icons/2018-10-01/446651996324_48.png',

--- a/test/slack.test.js
+++ b/test/slack.test.js
@@ -1,6 +1,5 @@
 const slackClient = require('../src/slack');
 const httpsMock = require('https');
-const querystring = require('node:querystring');
 jest.mock('https');
 
 describe('Slack Requests', () => {


### PR DESCRIPTION
email is in params instead of url encoded now